### PR TITLE
Feat/add refugee status

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,8 +18,8 @@ Nothing
 - Add `hash` method
 - Make id number instances immutable
 
-## [2.1.0] - 2023-04-05
+## [2.2.0] - 2023-04-05
 
 ### Added
 
-- Support for ID numbers where the citizen is a refugee. (See https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/South-Africa-TIN.pdf)
+- Support for [ID numbers where the citizen is a refugee.](https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/South-Africa-TIN.pdf)

--- a/CHANGES
+++ b/CHANGES
@@ -17,3 +17,9 @@ Nothing
 - Add equality operator `==` and `eql?` method
 - Add `hash` method
 - Make id number instances immutable
+
+## [2.1.0] - 2023-04-05
+
+### Added
+
+- Support for ID numbers where the citizen is a refugee. (See https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/South-Africa-TIN.pdf)

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,12 @@ and this project tries really hard to adhere to [Semantic Versioning](https://se
 
 Nothing
 
+## [2.2.0] - 2023-04-05
+
+### Added
+
+- Support for [ID numbers where the citizen is a refugee.](https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/South-Africa-TIN.pdf)
+
 ## [2.1.0] - 2022-05-31
 
 ### Added
@@ -17,9 +23,3 @@ Nothing
 - Add equality operator `==` and `eql?` method
 - Add `hash` method
 - Make id number instances immutable
-
-## [2.2.0] - 2023-04-05
-
-### Added
-
-- Support for [ID numbers where the citizen is a refugee.](https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/South-Africa-TIN.pdf)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A South African ID number is a 13-digit number which is defined by the following
 
 -	The first 6 digits (`YYMMDD`) are based on your date of birth. **20 February 1992** is displayed as `920220`.
 -	The next 4 digits (`SSSS`) are used to define your gender. Females are assigned numbers in the range 0000-4999 and males from 5000-9999.
--	The next digit (`C`) shows if you're a ZA citizen status, with 0 denoting that you were born a ZA citizen and 1 denoting that you're a permanent resident.
+-	The next digit (`C`) shows if you're a ZA citizen status, with 0 denoting that you were born a ZA citizen, 1 denoting that you're a permanent resident and 2 denoting that you're a refugee.
 -	The last digit (`Z`) is a checksum digit – used to check that the number sequence is accurate using a set formula called the [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm).
 
 The graphic below details the different sections of an ID number, based on the fictitious sequence `9202204720082`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ id_num.male?               # => false
 id_num.citizenship         # => :za_citizen
 id_num.za_citizen?         # => true
 id_num.permanent_resident? # => false
+id_num.refugee?            # => false
 ```
 
 Development

--- a/lib/za_id_number.rb
+++ b/lib/za_id_number.rb
@@ -8,9 +8,10 @@ class ZAIDNumber
   REQUIRED_ID_LENGTH = 13
   FEMALE_RANGE       = (0..4999)
   MALE_RANGE         = (5000..9999)
-  CITIZENSHIP_RANGE  = (0..1)
+  CITIZENSHIP_RANGE  = (0..2)
   ZA_CITIZEN         = 0
   PERMANENT_RESIDENT = 1
+  REFUGEE            = 2
 
   attr_reader :id_number
   alias to_s id_number
@@ -44,7 +45,7 @@ class ZAIDNumber
   end
 
   def valid_citizenship?
-    CITIZENSHIP_RANGE.include? @id_number[10].to_i
+    CITIZENSHIP_RANGE.include? citizenship_status
   end
 
   def date_of_birth
@@ -66,15 +67,23 @@ class ZAIDNumber
   end
 
   def citizenship
-    za_citizen? ? :za_citizen : :permanent_resident
+    case citizenship_status
+    when ZA_CITIZEN         then :za_citizen
+    when PERMANENT_RESIDENT then :permanent_resident
+    when REFUGEE            then :refugee
+    end
   end
 
   def za_citizen?
-    @id_number[10].to_i == ZA_CITIZEN
+    citizenship_status == ZA_CITIZEN
   end
 
   def permanent_resident?
     !za_citizen?
+  end
+
+  def refugee?
+    citizenship_status == REFUGEE
   end
 
   def ==(other)
@@ -86,5 +95,11 @@ class ZAIDNumber
 
   def hash
     id_number.hash
+  end
+
+  private
+
+  def citizenship_status
+    @id_number[10].to_i
   end
 end

--- a/lib/za_id_number/version.rb
+++ b/lib/za_id_number/version.rb
@@ -1,5 +1,5 @@
 class ZAIDNumber
   class Version
-    VERSION = '2.1.0'
+    VERSION = '2.2.0'
   end
 end

--- a/spec/za_id_number_spec.rb
+++ b/spec/za_id_number_spec.rb
@@ -49,7 +49,7 @@ describe ZAIDNumber do
 
     it "should only allow valid citizenship values" do
       expect(subject).to                                  be_valid_citizenship
-      expect(described_class.new("7501151234283")).to_not be_valid_citizenship
+      expect(described_class.new("7501151234383")).to_not be_valid_citizenship
     end
 
     it "should detect valid ZA ID number checksums" do
@@ -71,7 +71,7 @@ describe ZAIDNumber do
       expect(described_class.new("123456789015")).to_not  be_valid # all digits and has correct checksum, but too short
       expect(described_class.new("1234567A89012")).to_not be_valid # not all digits, but correct length
       expect(described_class.new("7513331234083")).to_not be_valid # all good, except date is bad.
-      expect(described_class.new("7501151234283")).to_not be_valid # all good, citizenship is bad
+      expect(described_class.new("7501151234383")).to_not be_valid # all good, citizenship is bad
       expect(described_class.new(invalid_za_id)).to_not   be_valid # all digits, and correct length, but bad checksum
     end
   end
@@ -100,6 +100,7 @@ describe ZAIDNumber do
   context "citizenship parsing" do
     let(:za_citizen)         { described_class.new 7501151234085.to_s }
     let(:permanent_resident) { described_class.new 7501151234184.to_s }
+    let(:refugee)            { described_class.new 7501151234283.to_s }
 
     it "should detect ZA citizens" do
       expect(za_citizen).to             be_za_citizen
@@ -109,6 +110,11 @@ describe ZAIDNumber do
     it "should detect permanent residents" do
       expect(permanent_resident).to             be_permanent_resident
       expect(permanent_resident.citizenship).to eq :permanent_resident
+    end
+
+    it "should detect refugees" do
+      expect(refugee).to             be_refugee
+      expect(refugee.citizenship).to eq :refugee
     end
   end
 end


### PR DESCRIPTION
ID validation is missing a status of 'refugee'. The citizen code can be between 0-2 where 2 is the refugee code.

See more: https://www.oecd.org/tax/automatic-exchange/crs-implementation-and-assistance/tax-identification-numbers/South-Africa-TIN.pdf